### PR TITLE
Better handling of title colors

### DIFF
--- a/title-colors.patch
+++ b/title-colors.patch
@@ -35,29 +35,44 @@ index f7e6b2ca3..796fe1e27 100644
  
  struct _ScreenInfo
 diff --git a/src/settings.c b/src/settings.c
-index c16946802..70df0e861 100644
+index c16946802..a6c5a1d74 100644
 --- a/src/settings.c
 +++ b/src/settings.c
-@@ -378,6 +378,25 @@ Decoration *getDecorationForColor(ScreenInfo *screen_info, guint32 color)
+@@ -378,6 +378,40 @@ Decoration *getDecorationForColor(ScreenInfo *screen_info, guint32 color)
          xfwmPixmapLoad (screen_info, &decoration->top[i][INACTIVE], theme, imagename, screen_info->colsym, color);
      }
  
 +    if (color == QUBES_LABEL_DOM0) {
++        /* For Dom0, use original title colors. */
 +        decoration->title_colors[0] = screen_info->title_colors[0];
 +        decoration->title_colors[1] = screen_info->title_colors[1];
++    } else if (color == 0x000000) {
++        /* This is a black label, override colors with light ones. */
++        decoration->title_colors[0] = qubes_title_colors_light[0];
++        decoration->title_colors[1] = qubes_title_colors_light[1];
 +    } else {
-+        gdouble h, s, v;
-+        gtk_rgb_to_hsv(
-+            1.0*((color & 0xFF0000) >> 16)/0xFF,
-+            1.0*((color & 0x00FF00) >>  8)/0xFF,
-+            1.0*((color & 0x0000FF) >>  0)/0xFF,
-+            &h, &s, &v);
-+        if (v < 0.2) {
-+            decoration->title_colors[0] = qubes_title_colors_light[0];
-+            decoration->title_colors[1] = qubes_title_colors_light[1];
-+        } else {
-+            decoration->title_colors[0] = qubes_title_colors_dark[0];
-+            decoration->title_colors[1] = qubes_title_colors_dark[1];
++        /*
++          For other windows, use the original colors, but tweak them to
++          improve contrast (make the dark ones darker, light ones brighter).
++
++          Note that some themes use opposite colors for active/inactive
++          windows, so the decision has to be made for these two colors
++          separately.
++        */
++        decoration->title_colors[0] = screen_info->title_colors[0];
++        decoration->title_colors[1] = screen_info->title_colors[1];
++
++        for (i = 0; i < 2; i++) {
++            GdkRGBA *c = &decoration->title_colors[i];
++            gdouble h, s, v;
++
++            gtk_rgb_to_hsv(c->red, c->green, c->blue, &h, &s, &v);
++            if (v < 0.6) {
++                v = v/2;
++            } else {
++                v = 1 - (1 - v)/2;
++            }
++            gtk_hsv_to_rgb(h, s, v, &c->red, &c->green, &c->blue);
 +        }
 +    }
 +
@@ -65,19 +80,14 @@ index c16946802..70df0e861 100644
      return decoration;
  }
 diff --git a/src/settings.h b/src/settings.h
-index ded3c3c36..f8924109e 100644
+index ded3c3c36..ecf709ce2 100644
 --- a/src/settings.h
 +++ b/src/settings.h
-@@ -182,6 +182,17 @@ static const guint qubes_label_colors[] = {
+@@ -182,6 +182,12 @@ static const guint qubes_label_colors[] = {
      0x000000,   /* QUBES_LABEL_BLACK */
  };
  
 +/* Title colors: active, inactive */
-+static const GdkRGBA qubes_title_colors_dark[2] = {
-+    { 0, 0, 0, 1 },
-+    { 0.3, 0.3, 0.3, 1},
-+};
-+
 +static const GdkRGBA qubes_title_colors_light[2] = {
 +    { 0.8, 0.8, 0.8, 1 },
 +    { 0.5, 0.5, 0.5, 1 },


### PR DESCRIPTION
Instead of overriding the color always, do so only for the black
title. Otherwise, try to improve the contrast.

See QubesOS/qubes-issues#5800.

---

I think a lot of difficulty here is because Qubes colorization is HSV based and changes the relative brightness of colors. So right now, for instance, a light (almost white) title bar, on which dark text is appropriate, becomes a deep blue one where we would prefer light text. 

Maybe there is some other model that would help. Still, tweaking the contrast is a useful hack, and maybe good enough for now :)

## Screenshots

Here are some screenshots. Note that the windows are usually _inactive_ in them, resulting in worse contrast (in the original theme, that's often by design).

## Qubes default

The contrast for inactive titles is improved, compared to status quo before my changes.

![image](https://user-images.githubusercontent.com/468495/81473543-80b11b80-91ff-11ea-99f8-fff82d38a2ce.png)

## Light title text

Looking really nice.

![image](https://user-images.githubusercontent.com/468495/81473560-93c3eb80-91ff-11ea-8389-f0f532856582.png)
![image](https://user-images.githubusercontent.com/468495/81473593-c40b8a00-91ff-11ea-9708-96706735ceaf.png)

## Light/dark

This one is tricky because active title is light, and inactive black, and it breaks if you don't follow that. Still, looks good.

![image](https://user-images.githubusercontent.com/468495/81473568-9f171700-91ff-11ea-8c5e-a63b14ca62ee.png)

## Broken ones

Some of the themes still look not very well, take a look at the white-on-yellow.

However, this is inactive title only, and active titles have black text and are perfectlyreadable.

![image](https://user-images.githubusercontent.com/468495/81473588-b950f500-91ff-11ea-8feb-648d496947e9.png)

![image](https://user-images.githubusercontent.com/468495/81473598-cf5eb580-91ff-11ea-8777-f639778ba57c.png)