### PR TITLE
[qubes-issues#9767]: Adding a patch for preventing potential user input interception 

### DIFF
--- a/0009-Update-defaults-to-prevent-input-interception.patch
+++ b/0009-Update-defaults-to-prevent-input-interception.patch
@@ -1,0 +1,32 @@
+From 9a724bda7814954dc63266bd94d20136b505645f Mon Sep 17 00:00:00 2001
+From: rsta79 <81906104+rsta79@users.noreply.github.com>
+Date: Fri, 14 Feb 2025 09:56:30 +0000
+Subject: [PATCH] fix: update defaults to prevent potential user input
+ interception
+
+---
+ defaults/defaults | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/defaults/defaults b/defaults/defaults
+index 83e873ff6..7fa1a8930 100644
+--- a/defaults/defaults
++++ b/defaults/defaults
+@@ -1,4 +1,4 @@
+-activate_action=bring
++activate_action=none
+ borderless_maximize=true
+ box_move=false
+ box_resize=false
+@@ -33,7 +33,7 @@ move_opacity=100
+ placement_mode=center
+ placement_ratio=20
+ popup_opacity=100
+-prevent_focus_stealing=false
++prevent_focus_stealing=true
+ raise_delay=250
+ raise_on_click=true
+ raise_on_focus=false
+-- 
+2.39.5
+

--- a/xfwm4.spec.in
+++ b/xfwm4.spec.in
@@ -19,6 +19,7 @@ Patch4: 0005-Qubes-decoration-handle-guivm-windows-prefix.patch
 Patch5: 0006-Qubes-decoration-title-colors.patch
 Patch6: 0007-Colors-overhaul.patch
 Patch7: 0008-Fail-safe-when-displaying-colors.patch
+Patch8: 0009-Update-defaults-to-prevent-input-interception.patch
 
 BuildRequires:  make
 BuildRequires:  gcc-c++


### PR DESCRIPTION
This PR only contains patch to change the defaults of xfwm4. Since xfwm4 don't have separate configuration file for user modified configurations, I'm uncertain whether QubesOS intends to secure that by overwriting configs that are potentially specified by the user, if that's the case we might need to write `%post` script for updating `~/.config/xfce4/xfconf/xfce-perchannel-xml/xfwm4.xml` the dom0.

Related: [qubes-issues#9767](https://github.com/QubesOS/qubes-issues/issues/9767)

Discussion: [QubesOS Forum](https://forum.qubes-os.org/t/discussion-my-proposal-to-change-default-xfce-xfwm-settings-in-dom0-for-security/32288)