### PR TITLE
Keep state files only when SaveOnExit is true

### DIFF
--- a/0009-Keep-state-files-only-when-SaveOnExit-is-true.patch
+++ b/0009-Keep-state-files-only-when-SaveOnExit-is-true.patch
@@ -1,0 +1,36 @@
+From 7d643cffc1df6ce61abbbf5f6dec3f09aadc7afd Mon Sep 17 00:00:00 2001
+From: Yassin Ahmed <eng.yassin.elbedwihy@gmail.com>
+Date: Thu, 26 Feb 2026 10:31:29 -0500
+Subject: [PATCH] Keep state files only when SaveOnExit is true
+
+---
+ src/session.c | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/src/session.c b/src/session.c
+index b9b202572..aa752d5d4 100644
+--- a/src/session.c
++++ b/src/session.c
+@@ -731,13 +731,18 @@ sessionSavePhase2 (XfceSMClient *session,
+                    DisplayInfo *display_info)
+ {
+     const gchar *filename;
++    XfconfChannel *session_channel;
++    gboolean save_on_exit;
+ 
+     g_return_if_fail (XFCE_IS_SM_CLIENT (session));
+     g_return_if_fail (session == display_info->session);
+ 
++    session_channel = xfconf_channel_get("xfce4-session");
++    save_on_exit = xfconf_channel_get_bool(session_channel, "/general/SaveOnExit", TRUE);
++
+     filename = xfce_sm_client_get_state_file (display_info->session);
+     DBG ("Saving session to \"%s\"", filename);
+-    if (filename)
++    if (filename && save_on_exit)
+     {
+         sessionSaveWindowStates (display_info, filename);
+     }
+-- 
+2.53.0
+

--- a/series-debian.conf
+++ b/series-debian.conf
@@ -6,4 +6,5 @@
 0006-Qubes-decoration-title-colors.patch
 0007-Colors-overhaul.patch
 0008-Fail-safe-when-displaying-colors.patch
+0009-Keep-state-files-only-when-SaveOnExit-is-true.patch
 0009-XXX-Reduce-error-trap-leak.patch

--- a/xfwm4.spec.in
+++ b/xfwm4.spec.in
@@ -19,6 +19,7 @@ Patch4: 0005-Qubes-decoration-handle-guivm-windows-prefix.patch
 Patch5: 0006-Qubes-decoration-title-colors.patch
 Patch6: 0007-Colors-overhaul.patch
 Patch7: 0008-Fail-safe-when-displaying-colors.patch
+Patch8: 0009-Keep-state-files-only-when-SaveOnExit-is-true.patch
 
 BuildRequires:  make
 BuildRequires:  gcc-c++


### PR DESCRIPTION
Upstream MR [here](https://gitlab.xfce.org/xfce/xfwm4/-/merge_requests/181) - Original MR by @mati7337 was conflicting with xfwm4's master.

SaveOnExit should now behave as the user expects, and this would make QubesOS (which uses xfwm4 by default) more secure since VM's shouldn't log the window titles of everything the user opens if the user explicitly states that `SaveOnExit=false`.